### PR TITLE
Remove duplicated :erlang.trace call

### DIFF
--- a/lib/my_system/runtime.ex
+++ b/lib/my_system/runtime.ex
@@ -1,8 +1,6 @@
 defmodule Runtime do
   def trace(pid) do
     Task.async(fn ->
-      :erlang.trace(pid, true, [:call])
-
       try do
         :erlang.trace(pid, true, [:call])
       rescue


### PR DESCRIPTION
Hi Sasa,

I was going through this source code and it seems `:erlang.trace` call is repeated

